### PR TITLE
修复全屏模式下卡顿并取消限制历史记录数功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,6 @@ Page({
             width: this.data.width,
             height: this.data.height,
             scale: this.data.scale,
-            getImagePath: () => {
-                return new Promise((resolve) => {
-                    ctx.toTempFilePath({
-                        success: res => resolve(res.filePath),
-                    })
-                })
-            }
         });
     },
     // 绑定touchstart事件
@@ -138,10 +131,6 @@ const signature = new Signature(ctx, {
 * Type: `string`
 * Default：
 
-**options.getImagePath**
-
-生成临时图片的Promise函数，用于保存历史记录，如该项未配置，则撤销功能不可用
-* Type: `promise`
 
 **options.toDataURL**
 
@@ -184,12 +173,6 @@ const signature = new Signature(ctx, {
 * Type: `number`
 * Default：20
 
-**options.maxHistoryLength**
-
-限制历史记录数，即最大可撤销数，传入0则关闭历史记录功能
-
-* Type: `number`
-* Default：20
 
 ### 实例属性/方法
 ```js
@@ -199,7 +182,7 @@ signature.ctx
 // 清屏
 signature.clear()
 
-// 撤销，如果未配置getImagePath，则不可用
+// 撤销
 signature.undo()
 
 // 获取base64图片，若未配置toDataURL，则不可用

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-smooth-signature",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "小程序带笔锋手写签名",
   "main": "lib/index.js",
   "module": "lib/index.js",
@@ -32,5 +32,6 @@
   "license": "MIT",
   "devDependencies": {
     "father": "^2.30.10"
-  }
+  },
+  "packageManager": "yarn@4.3.1+sha512.af78262d7d125afbfeed740602ace8c5e4405cd7f4735c08feb327286b2fdb2390fbca01589bfd1f50b1240548b74806767f5a063c94b67e431aabd0d86f7774"
 }


### PR DESCRIPTION
修复全屏模式下使用撤销功能时卡顿问题。
之前作者的做法是使用`canvas.toDataURL`来生成一个临时图片，用于维护每一笔画历史，但是在小程序（至少微信是这样）全屏模式下，该函数调用开效较大，需要将近100ms的时间，因此造成卡顿。
我目前的做法是将每一笔画产生的一系列点保存起来，时间上和空间上都得到优化，相关代码已在微信小程序上得到验证。